### PR TITLE
Gistのファイル名を指定して埋め込めるようにしました

### DIFF
--- a/sphinxcontrib/gist/gist.py
+++ b/sphinxcontrib/gist/gist.py
@@ -6,13 +6,18 @@ from docutils.parsers import rst
 
 
 class gist(nodes.General, nodes.Element):
-    pass
+    filename = ""
 
 
 
 def visit(self, node):
 
-    tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
+    if node.filename is not None:
+        tag = u'''<script
+        src="{0}.js?file={1}">&nbsp;</script>'''.format(node.url, 
+                node.filename)
+    else:
+        tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
 
     self.body.append(tag)
 
@@ -30,7 +35,7 @@ class GistDirective(rst.Directive):
 
     has_content = False
     required_arguments = 1
-    optional_arguments = 0
+    optional_arguments = 1
     final_argument_whitespace = False
     option_spec = {}
 
@@ -40,6 +45,8 @@ class GistDirective(rst.Directive):
         node = self.node_class()
 
         node.url = self.arguments[0]
+        if len(self.arguments) > 1:
+            node.filename = self.arguments[1]
 
         return [node]
 

--- a/testdoc/index.rst
+++ b/testdoc/index.rst
@@ -13,6 +13,8 @@ Contents:
 
 .. gist:: https://gist.github.com/shomah4a/5149412
 
+.. gist:: https://gist.github.com/shomah4a/5149412 git-やめる
+
 Indices and tables
 ==================
 


### PR DESCRIPTION
現状、1つのGistに複数のファイルがあるときに、すべてのファイルを埋め込んでしまいます。
1つのファイルだけを埋め込みたい場合に対応できるように、ファイル名を指定できるようにしました。

よければ本家に追加してください。
