### PR TITLE
Conditionally append `.js` at the end of `src`

### DIFF
--- a/sphinxcontrib/gist/gist.py
+++ b/sphinxcontrib/gist/gist.py
@@ -12,7 +12,10 @@ class gist(nodes.General, nodes.Element):
 
 def visit(self, node):
 
-    tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
+    if node.url.find(".js?file") != -1:
+        tag = u'''<script src="{0}">&nbsp;</script>'''.format(node.url)
+    else:
+        tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
 
     self.body.append(tag)
 


### PR DESCRIPTION
Do not add `.js` at the end of `src` link if the url contains specific file designator. This will allow users to use the file designator:

``` rest
.. gist:: https://gist.github.com/joonro/8a8965b3fe0f6b9dad08.js?file=subplots.py
```
