### PR TITLE
support gist file option

### DIFF
--- a/sphinxcontrib/gist/__init__.py
+++ b/sphinxcontrib/gist/__init__.py
@@ -26,7 +26,7 @@ finally, build your sphinx project.
 
 '''
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'
 __author__ = '@shomah4a'
 __license__ = 'LGPLv3'
 

--- a/sphinxcontrib/gist/gist.py
+++ b/sphinxcontrib/gist/gist.py
@@ -16,8 +16,6 @@ def visit(self, node):
     else:
         tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
 
-    print ("debug {0}".format(tag))
-
     self.body.append(tag)
 
 def depart(self, node):
@@ -47,4 +45,3 @@ class GistDirective(rst.Directive):
             node.file = ''
 
         return [node]
-    

--- a/sphinxcontrib/gist/gist.py
+++ b/sphinxcontrib/gist/gist.py
@@ -4,7 +4,6 @@ from docutils import nodes
 
 from docutils.parsers import rst
 
-
 class gist(nodes.General, nodes.Element):
     pass
 
@@ -12,16 +11,17 @@ class gist(nodes.General, nodes.Element):
 
 def visit(self, node):
 
-    tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
+    if len(node.file) > 0:
+        tag = u'''<script src="{0}.js?file={1}">&nbsp;</script>'''.format(node.url, node.file)
+    else:
+        tag = u'''<script src="{0}.js">&nbsp;</script>'''.format(node.url)
+
+    print ("debug {0}".format(tag))
 
     self.body.append(tag)
 
-
-
 def depart(self, node):
     pass
-
-
 
 class GistDirective(rst.Directive):
 
@@ -32,7 +32,7 @@ class GistDirective(rst.Directive):
     required_arguments = 1
     optional_arguments = 0
     final_argument_whitespace = False
-    option_spec = {}
+    option_spec = {'file': rst.directives.unchanged }
 
 
     def run(self):
@@ -41,5 +41,10 @@ class GistDirective(rst.Directive):
 
         node.url = self.arguments[0]
 
-        return [node]
+        if 'file' in self.options:
+            node.file = self.options['file']
+        else:
+            node.file = ''
 
+        return [node]
+    


### PR DESCRIPTION
Add option 'file'. It works for file selection of multiple files in gist.

下記のように、option fileで指定出来るようにしました。

```
.. gist:: https://gist.github.com/takekazuomi/583f0a3fc74a90ddbddb9c4febafea3f
   :file: storageProfile.json
````

関連

https://github.com/shomah4a/sphinx-gist-embed/pull/1

参考

http://stackoverflow.com/questions/14206307/how-do-i-embed-a-single-file-from-a-github-gist-with-the-new-gist-interface